### PR TITLE
:beetle: fixing a bug in build_values

### DIFF
--- a/lib/myers_diff.rb
+++ b/lib/myers_diff.rb
@@ -151,7 +151,7 @@ class MyersDiff
         component[:value] = join(old_string[old_pos, component[:count]])
         old_pos += component[:count]
 
-        if component_pos && components[component_pos - 1][:added]
+        if component_pos && 0 <= component_pos - 1 && components[component_pos - 1][:added]
           tmp = components[component_pos - 1]
           components[component_pos - 1] = components[component_pos]
           components[component_pos] = tmp

--- a/spec/myers_diff_spec.rb
+++ b/spec/myers_diff_spec.rb
@@ -18,6 +18,12 @@ RSpec.describe MyersDiff do
         expect(subject.size).to eq 8
       end
     end
+    describe 'abcd bde' do
+      subject { MyersDiff.new.diff('abcd', 'bde') }
+      it do
+        expect(subject.size).to eq 5
+      end
+    end
   end
 
   describe '#push_component' do


### PR DESCRIPTION
In Javascript, applying a negative index to an array will return null, but in Ruby, it will return the last element of the array. This caused erroneous results in `build_values`. To fix this, add a condition to make the behavior match the one in jsdiff.