### PR TITLE
:ok_hand: Improve word diff behavior

### DIFF
--- a/lib/myers_diff/word_diff.rb
+++ b/lib/myers_diff/word_diff.rb
@@ -1,5 +1,8 @@
 module MyersDiff
   class WordDiff
+    BOUNDARIES_REGEX = /(\s+|[()\[\]{}'"]|\b)/.freeze
+    EXTENDED_WORD_CHARS_REGEX = /^[a-zA-Z\u{C0}-\u{FF}\u{D8}-\u{F6}\u{F8}-\u{2C6}\u{2C8}-\u{2D7}\u{2DE}-\u{2FF}\u{1E00}-\u{1EFF}]+$/u.freeze
+
     def diff(s1, s2, **options)
       old_string = cast_input(s1)
       new_string = cast_input(s2)
@@ -117,11 +120,26 @@ module MyersDiff
     end
 
     def tokenize(str)
-      str.split(' ')
+      tokens = str.split(BOUNDARIES_REGEX)
+
+      i = 0
+      while i < tokens.size - 1
+        if tokens[i + 1].empty? && !tokens[i + 2].empty? &&
+            EXTENDED_WORD_CHARS_REGEX.match?(tokens[i]) &&
+            EXTENDED_WORD_CHARS_REGEX.match?(tokens[i + 2])
+          tokens[i] += tokens[i + 2]
+          tokens.delete_at(i + 1)
+          tokens.delete_at(i + 1)
+          i -= 1
+        end
+        i += 1
+      end
+
+      tokens
     end
 
     def join(chars)
-      chars.join(' ')
+      chars.join('')
     end
 
     # new_string - tokenized string i.e. array of strings

--- a/spec/myers_diff/word_diff_spec.rb
+++ b/spec/myers_diff/word_diff_spec.rb
@@ -37,7 +37,10 @@ RSpec.describe MyersDiff::WordDiff do
       let(:s2) { "I don't remember memories accurately when I was a child" }
 
       it do
-        expect(subject.size).to eq(5)
+        expect(subject.size).to eq(9)
+        expect(subject[0][:value]).to eq("I don't remember ")
+        expect(subject.find { |chunk| chunk[:removed] }[:value]).to eq('with')
+        expect(subject.find { |chunk| chunk[:added] }[:value]).to eq('memories')
       end
     end
 
@@ -46,7 +49,11 @@ RSpec.describe MyersDiff::WordDiff do
       let(:s2) { "I have no cousins." }
 
       it do
-        expect(subject.size).to eq(3)
+        expect(subject.size).to eq(4)
+        expect(subject.first[:value]).to eq('I have no ')
+        expect(subject.find { |chunk| chunk[:removed] }[:value]).to eq('cousin')
+        expect(subject.find { |chunk| chunk[:added] }[:value]).to eq('cousins')
+        expect(subject.last[:value]).to eq('.')
       end
     end
 
@@ -55,7 +62,9 @@ RSpec.describe MyersDiff::WordDiff do
       let(:s2) { "I prefer to work alone because I can work at my own pace." }
 
       it do
-        expect(subject.size).to eq(6)
+        expect(subject.size).to eq(7)
+        expect(subject.find { |chunk| chunk[:removed] }[:value]).to eq('on')
+        expect(subject.find { |chunk| chunk[:added] }[:value]).to eq('at')
       end
     end
 
@@ -64,7 +73,17 @@ RSpec.describe MyersDiff::WordDiff do
       let(:s2) { "I can share them on the Internet." }
 
       it do
-        expect(subject.size).to eq(5)
+        expect(subject.size).to eq(10)
+        expect(subject.last[:value]).to eq('on the Internet.')
+      end
+    end
+
+    context "when 'A miracle' vs 'A (miracle)'" do
+      let(:s1) { "A miracle" }
+      let(:s2) { "A (miracle)" }
+
+      it do
+        expect(subject.find { |chunk| chunk[:added] }[:value]).to eq('(')
       end
     end
   end


### PR DESCRIPTION
## Changes

* Split in a way that preserves whitespaces
* Also split on certain symbols like `[](){}'"`

Thanks [jsdiff](https://github.com/kpdecker/jsdiff), you're an awesome reference project.